### PR TITLE
out: make out command idempotent

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -48,6 +48,13 @@ version=$(extract_version $gem_file)
 
 configure_credentials
 
+if [ -n "$(gem search "$gem_name" -r -q -a | grep "$version")" ]
+then
+  echo "${gem_name}:${version} already published." >&2
+  jq -n "{ version: { number: \"$version\" } }" >&3
+  exit 0;
+fi
+
 echo "Publishing $(basename $gem_file)"
 
 gem push $gem_file \


### PR DESCRIPTION
👋 thanks for making this Concourse resource!

I ran into a small issue when publishing a gem using this resource, which I think this commit should fix.

Problem:

The [Implementing a Resource Type docs](https://concourse-ci.org/implementing-resource-types.html#implementing-resource-types) specify that an `out` script should idempotently push a version.

This Concourse resource's `out` script is not yet idempotent. If a job reruns with the same input an error message will be returned from RubyGems and the Concourse job will enter an error state:

```
$ gem push release.gem
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.
```

Solution:

This makes a `put` task using this resource succeed gracefully if multiple attempts to publish a gem version are made.